### PR TITLE
Fix list scrolling performance

### DIFF
--- a/NeoDB/NeoDB/ContentView.swift
+++ b/NeoDB/NeoDB/ContentView.swift
@@ -33,10 +33,6 @@ struct ContentView: View {
             // Home Tab
             NavigationStack(path: router.path(for: .timelines)) {
                 MastodonTimelinesView()
-                    .navigationDestination(for: RouterDestination.self) {
-                        destination in
-                        destinationView(for: destination)
-                    }
             }
             .tabItem {
                 Label(
@@ -49,10 +45,6 @@ struct ContentView: View {
             // Search Tab
             NavigationStack(path: router.path(for: .discover)) {
                 SearchView()
-                    .navigationDestination(for: RouterDestination.self) {
-                        destination in
-                        destinationView(for: destination)
-                    }
             }
             .tabItem {
                 Label(
@@ -65,10 +57,7 @@ struct ContentView: View {
             // Library Tab
             NavigationStack(path: router.path(for: .library)) {
                 LibraryView()
-                    .navigationDestination(for: RouterDestination.self) {
-                        destination in
-                        destinationView(for: destination)
-                    }
+                    
             }
             .tabItem {
                 Label(
@@ -80,10 +69,6 @@ struct ContentView: View {
             // Profile Tab
             NavigationStack(path: router.path(for: .profile)) {
                 SettingsView()
-                    .navigationDestination(for: RouterDestination.self) {
-                        destination in
-                        destinationView(for: destination)
-                    }
             }
             .tabItem {
                 Label(
@@ -91,6 +76,10 @@ struct ContentView: View {
                     systemImage: "gear")
             }
             .tag(TabDestination.profile)
+        }
+        .navigationDestination(for: RouterDestination.self) {
+            destination in
+            destinationView(for: destination)
         }
         .tint(.accentColor)
         .environmentObject(router)
@@ -101,13 +90,6 @@ struct ContentView: View {
                 router.presentSheet(.purchase)
             }
         }
-        .environment(
-            \.openURL,
-            OpenURLAction { url in
-                handleURL(url)
-                return .handled
-            }
-        )
         .sheet(
             item: Binding(
                 get: { router.sheetStack.last },

--- a/NeoDB/NeoDB/Views/Auth/TroubleshootingView.swift
+++ b/NeoDB/NeoDB/Views/Auth/TroubleshootingView.swift
@@ -64,7 +64,6 @@ class TroubleshootingViewModel: ObservableObject {
 
 struct TroubleshootingView: View {
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.openURL) private var openURL
     @StateObject private var viewModel: TroubleshootingViewModel
     @State private var showResetClientAlert = false
     

--- a/NeoDB/NeoDB/Views/Item/ItemView.swift
+++ b/NeoDB/NeoDB/Views/Item/ItemView.swift
@@ -15,7 +15,6 @@ struct ItemView: View {
     @EnvironmentObject private var router: Router
     @EnvironmentObject private var accountsManager: AppAccountsManager
     @EnvironmentObject private var storeManager: StoreManager
-    @Environment(\.openURL) private var openURL
 
     let id: String
     let category: ItemCategory

--- a/NeoDB/NeoDB/Views/Item/Shared/ItemOpenInView.swift
+++ b/NeoDB/NeoDB/Views/Item/Shared/ItemOpenInView.swift
@@ -14,8 +14,6 @@ struct ItemOpenInView: View {
     var router: Router? = nil
     var storeManager: StoreManager? = nil
 
-    @Environment(\.openURL) private var openURL
-
     private var shareURL: URL? {
         return URL(string: item.id)
     }

--- a/NeoDB/NeoDB/Views/MastodonStatus/Components/StatusView.swift
+++ b/NeoDB/NeoDB/Views/MastodonStatus/Components/StatusView.swift
@@ -103,7 +103,6 @@ struct StatusView: View {
                         }
 
                         if !content.characters.isEmpty {
-
                             Text(content)
                                 .environment(
                                     \.openURL,
@@ -116,7 +115,7 @@ struct StatusView: View {
                                 .lineLimit(isTimeline ? 5 : nil)
                         }
 
-                        if let item = status.content.links.compactMap(
+                        if let item = status.content.links.lazy.compactMap(
                             \.neodbItem
                         ).first, mode != .detailWithItem {
                             StatusItemView(item: item)
@@ -238,7 +237,9 @@ struct StatusView: View {
             if let destination = destination {
                 router.navigate(to: destination)
             } else {
-                openURL(url)
+                OpenURLAction(handler: { url in
+                    return .systemAction(url)
+                }).callAsFunction(url)
             }
         }
     }

--- a/NeoDB/NeoDB/Views/MastodonStatus/Components/StatusView.swift
+++ b/NeoDB/NeoDB/Views/MastodonStatus/Components/StatusView.swift
@@ -32,7 +32,6 @@ struct StatusView: View {
     let status: MastodonStatus
     let mode: StatusViewMode
 
-    @Environment(\.openURL) private var openURL
     @EnvironmentObject private var router: Router
     @EnvironmentObject private var accountsManager: AppAccountsManager
 

--- a/NeoDB/NeoDB/Views/MastodonTimelines/MastodonTimelinesView.swift
+++ b/NeoDB/NeoDB/Views/MastodonTimelines/MastodonTimelinesView.swift
@@ -32,11 +32,7 @@ struct MastodonTimelinesView: View {
                                     geometry: geometry
                                 )
                                 
-                                ProgressView()
-                                    .frame(maxWidth: .infinity)
-                                    .listRowInsets(EdgeInsets())
-                                    .listRowSeparator(.hidden)
-                                    .padding()
+                                LoadMoreIndicator()
                             }
                         }
                         .coordinateSpace(name: "scrollView")
@@ -193,6 +189,23 @@ struct MastodonTimelinesView: View {
     #if DEBUG
         @ObserveInjection var forceRedraw
     #endif
+    
+    struct LoadMoreIndicator: View {
+        @State private var id = UUID()
+        
+        var body: some View {
+            VStack {
+                ProgressView()
+                    .id(id)
+            }
+            .onAppear { self.id = UUID() }
+            .onDisappear { self.id = UUID() }
+            .frame(maxWidth: .infinity)
+            .listRowInsets(EdgeInsets())
+            .listRowSeparator(.hidden)
+            .padding()
+        }
+    }
 }
 
 #Preview {

--- a/NeoDB/NeoDB/Views/MastodonTimelines/MastodonTimelinesView.swift
+++ b/NeoDB/NeoDB/Views/MastodonTimelines/MastodonTimelinesView.swift
@@ -28,7 +28,15 @@ struct MastodonTimelinesView: View {
                         Group {
                             List {
                                 timelineContent(
-                                    for: type, geometry: geometry)
+                                    for: type,
+                                    geometry: geometry
+                                )
+                                
+                                ProgressView()
+                                    .frame(maxWidth: .infinity)
+                                    .listRowInsets(EdgeInsets())
+                                    .listRowSeparator(.hidden)
+                                    .padding()
                             }
                         }
                         .coordinateSpace(name: "scrollView")
@@ -143,7 +151,7 @@ struct MastodonTimelinesView: View {
             } else {
                 ForEach(state.statuses, id: \.id) { status in
                     VStack {
-                        if let item = status.content.links.compactMap(
+                        if let item = status.content.links.lazy.compactMap(
                             \.neodbItem
                         ).first {
                             Button {
@@ -168,19 +176,8 @@ struct MastodonTimelinesView: View {
                         return 4
                     }
                     .listRowInsets(EdgeInsets())
-                }
-                
-                if state.hasMore {
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                            .id(UUID())
-                        Spacer()
-                    }
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
-                    .padding()
                     .onAppear {
+                        guard status == state.statuses.last else { return }
                         if !state.isLoading {
                             Task {
                                 await viewModel.loadNextPage(type: type)


### PR DESCRIPTION
This PR includes:

- Removes `.environment(\.openURL, <#OpenURLAction#>)` to avoid unnecessary view refreshing when scrolling
- Merges `.navigationDestination(for:destination:)` together
- Removes view explicit id within a `List`
- Adds `lazy` for faster element iteration & query